### PR TITLE
fix audio bug（This change does not support 1.9）

### DIFF
--- a/qqplay/libs/qqplay-downloader.js
+++ b/qqplay/libs/qqplay-downloader.js
@@ -247,11 +247,10 @@ function downloadFont (item, callback) {
 }
 
 function downloadAudio (item, callback) {
-    item.content = item.url;
     var dom = document.createElement('audio');
     dom.src = item.url;
     item.element = dom;
-    callback(null, item.id);
+    callback(null, dom);
 }
 
 var extMap = {


### PR DESCRIPTION
之前改写 downloadAudio 方式是为了支持 1.9 audio preload 的方式做的，1.10 跟 2.0 audio 的资源类型改了，所以就不需要改成 callback id 了
https://github.com/cocos-creator/fireball/issues/7755
https://github.com/cocos-creator/fireball/issues/7753